### PR TITLE
Fix react-aspen crashing if an orphaned item is being rendered somehow?

### DIFF
--- a/src/components/ItemRendererWrap.tsx
+++ b/src/components/ItemRendererWrap.tsx
@@ -67,8 +67,12 @@ export class ItemRendererWrap extends React.Component<IItemRendererWrapProps> {
 				: this.props.itemType === ItemType.NewFilePrompt || this.props.itemType === ItemType.NewDirectoryPrompt
 					? (this.props.item as NewFilePromptHandle).parent
 					: null
-		if (thisItem && thisItem.path) {
-			this.lastItemPath = thisItem.path
+		try {
+			if (thisItem && thisItem.path) {
+				this.lastItemPath = thisItem.path
+			}
+		} catch (e) {
+			console.error(e)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #14 

It might be worth investigating how the heck an orphaned item even _gets_ here, but I can't repro it using the demo even using the exact same sequence of inotify events that cause this situation in my application.